### PR TITLE
Corrected docker build file

### DIFF
--- a/DevryBot/Dockerfile
+++ b/DevryBot/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/runtime:5.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build


### PR DESCRIPTION
Microsoft apparently uses aspnet:5.0 as their base image instead of runtime:5.0
Their templates need updating